### PR TITLE
[SANTUARIO-421] Use of algorithm from given parameter not field

### DIFF
--- a/src/main/java/org/apache/xml/security/encryption/XMLCipher.java
+++ b/src/main/java/org/apache/xml/security/encryption/XMLCipher.java
@@ -1764,13 +1764,13 @@ public class XMLCipher {
         }
 
         EncryptedData encryptedData = factory.newEncryptedData(element);
+        String encMethodAlgorithm = encryptedData.getEncryptionMethod().getAlgorithm();
 
         if (key == null) {
             KeyInfo ki = encryptedData.getKeyInfo();
             if (ki != null) {
                 try {
                     // Add an EncryptedKey resolver
-                    String encMethodAlgorithm = encryptedData.getEncryptionMethod().getAlgorithm();
                     EncryptedKeyResolver resolver = new EncryptedKeyResolver(encMethodAlgorithm, kek);
                     if (internalKeyResolvers != null) {
                         int size = internalKeyResolvers.size();
@@ -1803,7 +1803,7 @@ public class XMLCipher {
 
         // Now create the working cipher
         String jceAlgorithm = 
-            JCEMapper.translateURItoJCEID(encryptedData.getEncryptionMethod().getAlgorithm());
+            JCEMapper.translateURItoJCEID(encMethodAlgorithm);
         if (log.isDebugEnabled()) {
             log.debug("JCE Algorithm = " + jceAlgorithm);
         }
@@ -1823,7 +1823,7 @@ public class XMLCipher {
             throw new XMLEncryptionException(nspae);
         }
 
-        int ivLen = JCEMapper.getIVLengthFromURI(encryptedData.getEncryptionMethod().getAlgorithm()) / 8;
+        int ivLen = JCEMapper.getIVLengthFromURI(encMethodAlgorithm) / 8;
         byte[] ivBytes = new byte[ivLen];
 
         // You may be able to pass the entire piece in to IvParameterSpec
@@ -1832,7 +1832,7 @@ public class XMLCipher {
         // necessary bytes into a dedicated array.
 
         System.arraycopy(encryptedBytes, 0, ivBytes, 0, ivLen);
-        AlgorithmParameterSpec paramSpec = constructBlockCipherParameters(algorithm, ivBytes);
+        AlgorithmParameterSpec paramSpec = constructBlockCipherParameters(encMethodAlgorithm, ivBytes);
 
         try {
             c.init(cipherMode, key, paramSpec);

--- a/src/test/java/org/apache/xml/security/test/dom/encryption/XMLCipherTest.java
+++ b/src/test/java/org/apache/xml/security/test/dom/encryption/XMLCipherTest.java
@@ -21,6 +21,7 @@ package org.apache.xml.security.test.dom.encryption;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.InputStream;
 import java.security.Key;
 import java.security.KeyPairGenerator;
 import java.security.KeyPair;
@@ -863,6 +864,27 @@ public class XMLCipherTest extends org.junit.Assert {
                 keyCipher.loadEncryptedKey(document, (Element) ekList.item(i));
             assertNotNull(ek.getRecipient());
         }
+    }
+
+    @org.junit.Test
+    public void testEecryptToByteArray() throws Exception {
+        KeyGenerator keygen = KeyGenerator.getInstance("AES");
+        keygen.init(128);
+        Key key = keygen.generateKey();
+
+        Document document = document();
+
+        XMLCipher cipher = XMLCipher.getInstance(XMLCipher.AES_128_GCM);
+        cipher.init(XMLCipher.ENCRYPT_MODE, key);
+        EncryptedData builder = cipher.getEncryptedData();
+
+        Document encrypted = cipher.doFinal(document, document);
+
+        XMLCipher xmlCipher = XMLCipher.getInstance();
+        xmlCipher.init(XMLCipher.DECRYPT_MODE, key);
+        Element encryptedData = (Element) document.getElementsByTagNameNS(EncryptionConstants.EncryptionSpecNS, EncryptionConstants._TAG_ENCRYPTEDDATA).item(0);
+
+        xmlCipher.decryptToByteArray(encryptedData);
     }
 
     private String toString (Node n) throws Exception {


### PR DESCRIPTION
XMLCipher.decryptToByteArray uses algorithm from instance field not the given element argument. XMLCipher can be initialised without algorithm, in that case algorithm field remains to be null. With algorithm field null proper selection of algorithm parameters (e.g. when using GCM mode) is not performed.
