### PR TITLE
SANTUARIO-452 Set KeyName value from XMLSecurityProperties

### DIFF
--- a/src/main/java/org/apache/xml/security/resource/xmlsecurity_de.properties
+++ b/src/main/java/org/apache/xml/security/resource/xmlsecurity_de.properties
@@ -186,3 +186,4 @@ stax.namedCurveMissing = NamedCurve fehlt.
 stax.encryption.securePartNotFound = Part zum Verschl\u00fcsseln nicht gefunden: {0}
 stax.signature.securePartNotFound = Part zum Signieren nicht gefunden: {0}
 stax.multipleSignaturesNotSupported = Mehrere Signaturen werden nicht unterstützt.
+stax.signature.keyNameMissing = KeyName nicht konfiguriert.

--- a/src/main/java/org/apache/xml/security/resource/xmlsecurity_en.properties
+++ b/src/main/java/org/apache/xml/security/resource/xmlsecurity_en.properties
@@ -186,3 +186,4 @@ stax.namedCurveMissing = NamedCurve is missing.
 stax.encryption.securePartNotFound = Part to encrypt not found: {0}
 stax.signature.securePartNotFound = Part to sign not found: {0}
 stax.multipleSignaturesNotSupported = Multiple signatures are not supported.
+stax.signature.keyNameMissing = KeyName not configured.

--- a/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityProperties.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityProperties.java
@@ -54,6 +54,7 @@ public class XMLSecurityProperties {
     private Key encryptionKey;
     private Key encryptionTransportKey;
     private SecurityTokenConstants.KeyIdentifier encryptionKeyIdentifier;
+    private String encryptionKeyName;
 
     private Key decryptionKey;
 
@@ -65,6 +66,7 @@ public class XMLSecurityProperties {
     private X509Certificate[] signatureCerts;
     private boolean addExcC14NInclusivePrefixes = false;
     private SecurityTokenConstants.KeyIdentifier signatureKeyIdentifier;
+    private String signatureKeyName;
     private boolean useSingleCert = true;
 
     private Key signatureVerificationKey;
@@ -104,6 +106,8 @@ public class XMLSecurityProperties {
         this.signatureVerificationKey = xmlSecurityProperties.signatureVerificationKey;
         this.signaturePosition = xmlSecurityProperties.signaturePosition;
         this.idAttributeNS = xmlSecurityProperties.idAttributeNS;
+        this.signatureKeyName = xmlSecurityProperties.signatureKeyName;
+        this.encryptionKeyName = xmlSecurityProperties.encryptionKeyName;
     }
 
     public SecurityTokenConstants.KeyIdentifier getSignatureKeyIdentifier() {
@@ -419,5 +423,31 @@ public class XMLSecurityProperties {
 
     public void setDisableSchemaValidation(boolean disableSchemaValidation) {
         this.disableSchemaValidation = disableSchemaValidation;
+    }
+
+    public String getSignatureKeyName() {
+        return signatureKeyName;
+    }
+
+    /**
+     * specifies the contents of the KeyInfo/KeyName element for signing
+     *
+     * @param signatureKeyName set to a String that will be passed as contents of the KeyName element
+     */
+    public void setSignatureKeyName(String signatureKeyName) {
+        this.signatureKeyName = signatureKeyName;
+    }
+
+    public String getEncryptionKeyName() {
+        return encryptionKeyName;
+    }
+
+    /**
+     * specifies the contents of the KeyInfo/KeyName element for encryption
+     *
+     * @param encryptionKeyName set to a String that will be passed as contents of the KeyName element
+     */
+    public void setEncryptionKeyName(String encryptionKeyName) {
+        this.encryptionKeyName = encryptionKeyName;
     }
 }

--- a/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityUtils.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityUtils.java
@@ -28,6 +28,7 @@ import org.apache.xml.security.stax.ext.stax.XMLSecAttribute;
 import org.apache.xml.security.stax.ext.stax.XMLSecEvent;
 import org.apache.xml.security.stax.ext.stax.XMLSecNamespace;
 import org.apache.xml.security.stax.ext.stax.XMLSecStartElement;
+import org.apache.xml.security.stax.impl.processor.output.XMLSignatureEndingOutputProcessor;
 import org.apache.xml.security.stax.impl.util.ConcreteLSInput;
 import org.apache.xml.security.stax.securityEvent.*;
 import org.apache.xml.security.stax.securityToken.InboundSecurityToken;
@@ -497,4 +498,15 @@ public class XMLSecurityUtils {
         return schema;
     }
 
+    public static void createKeyNameTokenStructure(AbstractOutputProcessor abstractOutputProcessor, OutputProcessorChain outputProcessorChain, String keyName)
+            throws XMLStreamException, XMLSecurityException {
+
+        if (keyName == null || keyName.isEmpty()) {
+            throw new XMLSecurityException("stax.signature.keyNameMissing");
+        }
+
+        abstractOutputProcessor.createStartElementAndOutputAsEvent(outputProcessorChain, XMLSecurityConstants.TAG_dsig_KeyName, true, null);
+        abstractOutputProcessor.createCharactersAndOutputAsEvent(outputProcessorChain, keyName);
+        abstractOutputProcessor.createEndElementAndOutputAsEvent(outputProcessorChain, XMLSecurityConstants.TAG_dsig_KeyName);
+    }
 }

--- a/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityUtils.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityUtils.java
@@ -28,7 +28,6 @@ import org.apache.xml.security.stax.ext.stax.XMLSecAttribute;
 import org.apache.xml.security.stax.ext.stax.XMLSecEvent;
 import org.apache.xml.security.stax.ext.stax.XMLSecNamespace;
 import org.apache.xml.security.stax.ext.stax.XMLSecStartElement;
-import org.apache.xml.security.stax.impl.processor.output.XMLSignatureEndingOutputProcessor;
 import org.apache.xml.security.stax.impl.util.ConcreteLSInput;
 import org.apache.xml.security.stax.securityEvent.*;
 import org.apache.xml.security.stax.securityToken.InboundSecurityToken;

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLEncryptOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLEncryptOutputProcessor.java
@@ -295,6 +295,9 @@ public class XMLEncryptOutputProcessor extends AbstractEncryptOutputProcessor {
                                 XMLSecurityUtils.createX509CertificateStructure(this, outputProcessorChain, x509Certificates);
                             } else if (SecurityTokenConstants.KeyIdentifier_X509SubjectName.equals(keyIdentifier)) {
                                 XMLSecurityUtils.createX509SubjectNameStructure(this, outputProcessorChain, x509Certificates);
+                            } else if (SecurityTokenConstants.KeyIdentifier_KeyName.equals(keyIdentifier)) {
+                                String keyName = getSecurityProperties().getEncryptionKeyName();
+                                XMLSecurityUtils.createKeyNameTokenStructure(this, outputProcessorChain, keyName);
                             } else {
                                 throw new XMLSecurityException("stax.unsupportedToken",
                                                                new Object[] {keyIdentifier});

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLSignatureEndingOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLSignatureEndingOutputProcessor.java
@@ -142,6 +142,9 @@ public class XMLSignatureEndingOutputProcessor extends AbstractSignatureEndingOu
                 XMLSecurityUtils.createX509CertificateStructure(this, outputProcessorChain, x509Certificates);
             } else if (SecurityTokenConstants.KeyIdentifier_X509SubjectName.equals(keyIdentifier)) {
                 XMLSecurityUtils.createX509SubjectNameStructure(this, outputProcessorChain, x509Certificates);
+            } else if (SecurityTokenConstants.KeyIdentifier_KeyName.equals(keyIdentifier)) {
+                String keyName = getSecurityProperties().getSignatureKeyName();
+                XMLSecurityUtils.createKeyNameTokenStructure(this, outputProcessorChain, keyName);
             } else {
                 throw new XMLSecurityException("stax.unsupportedToken",
                                                new Object[] {keyIdentifier});

--- a/src/test/java/org/apache/xml/security/test/stax/encryption/EncryptionCreationTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/encryption/EncryptionCreationTest.java
@@ -588,6 +588,74 @@ public class EncryptionCreationTest extends Assert {
     }
 
     @Test
+    public void testEncryptedKeyKeyNameReference() throws Exception {
+        // Set up the Configuration
+        XMLSecurityProperties properties = new XMLSecurityProperties();
+        List<XMLSecurityConstants.Action> actions = new ArrayList<XMLSecurityConstants.Action>();
+        actions.add(XMLSecurityConstants.ENCRYPT);
+        properties.setActions(actions);
+
+        // Set the key up
+        // Generate an RSA key
+        KeyPairGenerator rsaKeygen = KeyPairGenerator.getInstance("RSA");
+        KeyPair kp = rsaKeygen.generateKeyPair();
+        PrivateKey priv = kp.getPrivate();
+        PublicKey pub = kp.getPublic();
+        properties.setEncryptionTransportKey(pub);
+        properties.setEncryptionKeyTransportAlgorithm("http://www.w3.org/2001/04/xmlenc#rsa-1_5");
+
+        KeyGenerator keygen = KeyGenerator.getInstance("AES");
+        keygen.init(256);
+        SecretKey key = keygen.generateKey();
+        properties.setEncryptionKey(key);
+        properties.setEncryptionSymAlgorithm("http://www.w3.org/2001/04/xmlenc#aes256-cbc");
+        properties.setEncryptionKeyIdentifier(SecurityTokenConstants.KeyIdentifier_KeyName);
+        properties.setEncryptionKeyName("PublicKey");
+
+        SecurePart securePart =
+                new SecurePart(new QName("urn:example:po", "PaymentInfo"), SecurePart.Modifier.Element);
+        properties.addEncryptionPart(securePart);
+
+        OutboundXMLSec outboundXMLSec = XMLSec.getOutboundXMLSec(properties);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        XMLStreamWriter xmlStreamWriter = outboundXMLSec.processOutMessage(baos, "UTF-8");
+
+        InputStream sourceDocument =
+                this.getClass().getClassLoader().getResourceAsStream(
+                        "ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml");
+        XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(sourceDocument);
+
+        XmlReaderToWriter.writeAll(xmlStreamReader, xmlStreamWriter);
+        xmlStreamWriter.close();
+
+        // System.out.println("Got:\n" + new String(baos.toByteArray(), "UTF-8"));
+
+        Document document =
+                XMLUtils.createDocumentBuilder(false).parse(new ByteArrayInputStream(baos.toByteArray()));
+
+        NodeList nodeList = document.getElementsByTagNameNS("urn:example:po", "PaymentInfo");
+        Assert.assertEquals(nodeList.getLength(), 0);
+
+        // Check the CreditCard encrypted ok
+        nodeList = document.getElementsByTagNameNS("urn:example:po", "CreditCard");
+        Assert.assertEquals(nodeList.getLength(), 0);
+
+        nodeList = document.getElementsByTagNameNS(
+                XMLSecurityConstants.TAG_xenc_EncryptedData.getNamespaceURI(),
+                XMLSecurityConstants.TAG_xenc_EncryptedData.getLocalPart()
+        );
+        Assert.assertEquals(nodeList.getLength(), 1);
+
+        // Decrypt using DOM API
+        Document doc =
+                decryptUsingDOM("http://www.w3.org/2001/04/xmlenc#tripledes-cbc", null, priv, document);
+
+        // Check the CreditCard decrypted ok
+        nodeList = doc.getElementsByTagNameNS("urn:example:po", "CreditCard");
+        Assert.assertEquals(nodeList.getLength(), 1);
+    }
+
+    @Test
     public void testEncryptedKeyMultipleElements() throws Exception {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();

--- a/src/test/java/org/apache/xml/security/test/stax/signature/SignatureCreationTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/signature/SignatureCreationTest.java
@@ -1330,7 +1330,7 @@ public class SignatureCreationTest extends AbstractSignatureCreationTest {
 
         NodeList nodeList = document.getElementsByTagNameNS(XMLSecurityConstants.TAG_dsig_KeyName.getNamespaceURI(), XMLSecurityConstants.TAG_dsig_KeyName.getLocalPart());
         assertEquals(1, nodeList.getLength());
-        assertEquals("CN=transmitter, OU=swssf, C=CH", nodeList.item(0).getFirstChild().getTextContent());
+        assertEquals(cert.getIssuerDN().getName(), nodeList.item(0).getFirstChild().getTextContent());
 
         // Verify using DOM
         verifyUsingDOM(document, cert, properties.getSignatureSecureParts());

--- a/src/test/java/org/apache/xml/security/test/stax/signature/SignatureCreationTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/signature/SignatureCreationTest.java
@@ -1286,4 +1286,53 @@ public class SignatureCreationTest extends AbstractSignatureCreationTest {
         verifyUsingDOM(document, cert, properties.getSignatureSecureParts(), null, false, "Id");
 
     }
+
+    @Test
+    public void testSignatureCreationKeyName() throws Exception {
+        // Set up the Configuration
+        XMLSecurityProperties properties = new XMLSecurityProperties();
+        List<XMLSecurityConstants.Action> actions = new ArrayList<XMLSecurityConstants.Action>();
+        actions.add(XMLSecurityConstants.SIGNATURE);
+        properties.setActions(actions);
+        properties.setSignatureKeyIdentifier(SecurityTokenConstants.KeyIdentifier_KeyName);
+
+        // Set the key up
+        KeyStore keyStore = KeyStore.getInstance("jks");
+        keyStore.load(
+                this.getClass().getClassLoader().getResource("transmitter.jks").openStream(),
+                "default".toCharArray()
+        );
+        Key key = keyStore.getKey("transmitter", "default".toCharArray());
+        properties.setSignatureKey(key);
+        X509Certificate cert = (X509Certificate)keyStore.getCertificate("transmitter");
+        properties.setSignatureCerts(new X509Certificate[]{cert});
+        properties.setSignatureKeyName(cert.getIssuerDN().getName());
+
+        SecurePart securePart =
+                new SecurePart(new QName("urn:example:po", "PaymentInfo"), SecurePart.Modifier.Content);
+        properties.addSignaturePart(securePart);
+
+        OutboundXMLSec outboundXMLSec = XMLSec.getOutboundXMLSec(properties);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        XMLStreamWriter xmlStreamWriter = outboundXMLSec.processOutMessage(baos, "UTF-8");
+
+        InputStream sourceDocument =
+                this.getClass().getClassLoader().getResourceAsStream(
+                        "ie/baltimore/merlin-examples/merlin-xmlenc-five/plaintext.xml");
+        XMLStreamReader xmlStreamReader = xmlInputFactory.createXMLStreamReader(sourceDocument);
+
+        XmlReaderToWriter.writeAll(xmlStreamReader, xmlStreamWriter);
+        xmlStreamWriter.close();
+
+        // System.out.println("Got:\n" + new String(baos.toByteArray(), "UTF-8"));
+        Document document =
+                XMLUtils.createDocumentBuilder(false).parse(new ByteArrayInputStream(baos.toByteArray()));
+
+        NodeList nodeList = document.getElementsByTagNameNS(XMLSecurityConstants.TAG_dsig_KeyName.getNamespaceURI(), XMLSecurityConstants.TAG_dsig_KeyName.getLocalPart());
+        assertEquals(1, nodeList.getLength());
+        assertEquals("CN=transmitter, OU=swssf, C=CH", nodeList.item(0).getFirstChild().getTextContent());
+
+        // Verify using DOM
+        verifyUsingDOM(document, cert, properties.getSignatureSecureParts());
+    }
 }


### PR DESCRIPTION
This patch allows a user of the santuario library to pass a value that will be put in the KeyInfo/KeyName element when the KeyIndentifier type is set to "KeyName".
