### PR TITLE
Allow users to set a SecurityEventListener on the OutboundSecurityCon…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /.classpath
 /.project
 /target/
+
+.pmd
+.pmdruleset.xml
+/.settings/

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -9,4 +9,5 @@ org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.8

--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <targetJdk>1.8</targetJdk>
         <clirr.version>2.8</clirr.version>
-
+		<jsr305.version>3.0.1</jsr305.version>
         <!-- Allow Clirr severity to be overriden by the command-line option -DminSeverity=level -->
         <minSeverity>info</minSeverity>
     </properties>
@@ -607,6 +607,12 @@
             <version>${bcprov.version}</version>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>${jsr305.version}</version>
+		</dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/org/apache/xml/security/stax/ext/OutboundXMLSec.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/OutboundXMLSec.java
@@ -26,20 +26,25 @@ import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.crypto.KeyGenerator;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.apache.xml.security.exceptions.XMLSecurityException;
 import org.apache.xml.security.stax.config.JCEAlgorithmMapper;
-import org.apache.xml.security.stax.securityToken.SecurityTokenConstants;
-import org.apache.xml.security.stax.securityToken.SecurityTokenProvider;
-import org.apache.xml.security.stax.impl.*;
+import org.apache.xml.security.stax.impl.DocumentContextImpl;
+import org.apache.xml.security.stax.impl.OutboundSecurityContextImpl;
+import org.apache.xml.security.stax.impl.OutputProcessorChainImpl;
+import org.apache.xml.security.stax.impl.XMLSecurityStreamWriter;
 import org.apache.xml.security.stax.impl.processor.output.FinalOutputProcessor;
 import org.apache.xml.security.stax.impl.processor.output.XMLEncryptOutputProcessor;
 import org.apache.xml.security.stax.impl.processor.output.XMLSignatureOutputProcessor;
 import org.apache.xml.security.stax.impl.securityToken.GenericOutboundSecurityToken;
-import org.apache.xml.security.stax.securityToken.OutboundSecurityToken;
 import org.apache.xml.security.stax.impl.util.IDGenerator;
+import org.apache.xml.security.stax.securityEvent.SecurityEventListener;
+import org.apache.xml.security.stax.securityToken.OutboundSecurityToken;
+import org.apache.xml.security.stax.securityToken.SecurityTokenConstants;
+import org.apache.xml.security.stax.securityToken.SecurityTokenProvider;
 
 /**
  * Outbound Streaming-XML-Security
@@ -63,7 +68,7 @@ public class OutboundXMLSec {
      * @throws XMLSecurityException thrown when a Security failure occurs
      */
     public XMLStreamWriter processOutMessage(OutputStream outputStream, String encoding) throws XMLSecurityException {
-        return processOutMessage((Object)outputStream, encoding);
+        return processOutMessage(outputStream, encoding, null);
     }
 
     /**
@@ -75,11 +80,22 @@ public class OutboundXMLSec {
      * @throws XMLSecurityException thrown when a Security failure occurs
      */
     public XMLStreamWriter processOutMessage(XMLStreamWriter xmlStreamWriter, String encoding) throws XMLSecurityException {
-        return processOutMessage((Object)xmlStreamWriter, encoding);
+        return processOutMessage((Object)xmlStreamWriter, encoding, null);
+    }
+    
+    public XMLStreamWriter processOutMessage(
+    		XMLStreamWriter xmlStreamWriter, String encoding, @Nullable SecurityEventListener eventListener) throws XMLSecurityException {
+    	return processOutMessage((Object) xmlStreamWriter, encoding, eventListener);
     }
 
-    private XMLStreamWriter processOutMessage(Object output, String encoding) throws XMLSecurityException {
+    private XMLStreamWriter processOutMessage(
+    		Object output, String encoding, @Nullable SecurityEventListener eventListener) throws XMLSecurityException {
         final OutboundSecurityContextImpl outboundSecurityContext = new OutboundSecurityContextImpl();
+        
+        if (eventListener != null) {
+        	outboundSecurityContext.addSecurityEventListener(eventListener);
+        }
+        
         final DocumentContextImpl documentContext = new DocumentContextImpl();
         documentContext.setEncoding(encoding);
 


### PR DESCRIPTION
…textImpl. This allows users to recover the generated signature when writing and signing an XML document. Recovering the signature is important for audit reasons.