### PR TITLE
SANTUARIO-523 XMLSecurityStreamReader now correctly reads info from XML declaration

### DIFF
--- a/src/main/java/org/apache/xml/security/stax/impl/XMLSecurityStreamReader.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/XMLSecurityStreamReader.java
@@ -33,6 +33,7 @@ import javax.xml.stream.events.DTD;
 import javax.xml.stream.events.EntityReference;
 import javax.xml.stream.events.Namespace;
 import javax.xml.stream.events.ProcessingInstruction;
+import javax.xml.stream.events.StartDocument;
 
 import org.apache.xml.security.exceptions.XMLSecurityException;
 import org.apache.xml.security.stax.ext.InputProcessorChain;
@@ -49,7 +50,11 @@ public class XMLSecurityStreamReader implements XMLStreamReader {
 
     private final InputProcessorChain inputProcessorChain;
     private XMLSecEvent currentXMLSecEvent;
-    private boolean skipDocumentEvents = false;
+    private final boolean skipDocumentEvents;
+    private String version;
+    private boolean standalone;
+    private boolean standaloneSet;
+    private String characterEncodingScheme;
 
     private static final String ERR_STATE_NOT_ELEM = "Current state not START_ELEMENT or END_ELEMENT";
     private static final String ERR_STATE_NOT_STELEM = "Current state not START_ELEMENT";
@@ -75,9 +80,18 @@ public class XMLSecurityStreamReader implements XMLStreamReader {
             inputProcessorChain.reset();
             currentXMLSecEvent = inputProcessorChain.processEvent();
             eventType = currentXMLSecEvent.getEventType();
-            if (eventType == START_DOCUMENT && this.skipDocumentEvents) {
-                currentXMLSecEvent = inputProcessorChain.processEvent();
-                eventType = currentXMLSecEvent.getEventType();
+            if (eventType == START_DOCUMENT) {
+                // Even when skipDocumentEvents is true, we still want to get the information out of the event.
+                // We only skip the event itself.
+                StartDocument startDocument = (StartDocument) currentXMLSecEvent;
+                version = startDocument.getVersion();
+                characterEncodingScheme = startDocument.getCharacterEncodingScheme();
+                standalone = startDocument.isStandalone();
+                standaloneSet = startDocument.standaloneSet();
+                if (skipDocumentEvents) {
+                    currentXMLSecEvent = inputProcessorChain.processEvent();
+                    eventType = currentXMLSecEvent.getEventType();
+                }
             }
         } catch (XMLSecurityException e) {
             throw new XMLStreamException(e);
@@ -592,22 +606,22 @@ public class XMLSecurityStreamReader implements XMLStreamReader {
 
     @Override
     public String getVersion() {
-        return null;
+        return version;
     }
 
     @Override
     public boolean isStandalone() {
-        return false;
+        return standalone;
     }
 
     @Override
     public boolean standaloneSet() {
-        return false;
+        return standaloneSet;
     }
 
     @Override
     public String getCharacterEncodingScheme() {
-        return null;
+        return characterEncodingScheme;
     }
 
     @Override

--- a/src/test/java/org/apache/xml/security/test/stax/utils/XmlReaderToWriter.java
+++ b/src/test/java/org/apache/xml/security/test/stax/utils/XmlReaderToWriter.java
@@ -31,6 +31,13 @@ public final class XmlReaderToWriter {
 
     public static void writeAll(XMLStreamReader xmlr, XMLStreamWriter writer)
             throws XMLStreamException {
+        // Some implementations, Woodstox for example, already position their reader ON the first event, which is.
+        // typically a START_DOCUMENT event.
+        // If already positioned on an event, that is indicated by the event type.
+        // Make sure we don't miss the initial event.
+        if (xmlr.getEventType() > 0) {
+            write(xmlr, writer);
+        }
         while (xmlr.hasNext()) {
             xmlr.next();
             write(xmlr, writer);


### PR DESCRIPTION
XMLSecurityStreamReader now correctly reads version, encoding and standalone-ness from the XML declaration.