### PR TITLE
SANTUARIO-525 Made Base64 line length and line separator configurable…

### DIFF
--- a/src/main/java/org/apache/xml/security/signature/XMLSignature.java
+++ b/src/main/java/org/apache/xml/security/signature/XMLSignature.java
@@ -661,11 +661,6 @@ public final class XMLSignature extends SignatureElementProxy {
         }
 
         String base64codedValue = XMLUtils.encodeToString(bytes);
-
-        if (base64codedValue.length() > 76 && !XMLUtils.ignoreLineBreaks()) {
-            base64codedValue = "\n" + base64codedValue + "\n";
-        }
-
         Text t = createText(base64codedValue);
         signatureValueElement.appendChild(t);
     }

--- a/src/main/java/org/apache/xml/security/stax/ext/AbstractOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/AbstractOutputProcessor.java
@@ -37,6 +37,7 @@ import org.apache.xml.security.stax.ext.stax.XMLSecEvent;
 import org.apache.xml.security.stax.ext.stax.XMLSecEventFactory;
 import org.apache.xml.security.stax.ext.stax.XMLSecNamespace;
 import org.apache.xml.security.stax.ext.stax.XMLSecStartElement;
+import org.apache.xml.security.utils.XMLUtils;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -72,6 +73,7 @@ public abstract class AbstractOutputProcessor implements OutputProcessor {
 
     @Override
     public void init(OutputProcessorChain outputProcessorChain) throws XMLSecurityException {
+        XMLUtils.setThreadLocalBase64Parameters(securityProperties.getBase64LineLength(), securityProperties.getBase64LineSeparator());
         outputProcessorChain.addProcessor(this);
     }
 

--- a/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityProperties.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityProperties.java
@@ -18,14 +18,15 @@
  */
 package org.apache.xml.security.stax.ext;
 
-import org.apache.xml.security.stax.securityToken.SecurityTokenConstants;
-
 import java.security.Key;
 import java.security.cert.X509Certificate;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.*;
 
 import javax.xml.namespace.QName;
+
+import org.apache.xml.security.stax.securityToken.SecurityTokenConstants;
+import org.apache.xml.security.utils.XMLUtils;
 
 
 /**
@@ -80,6 +81,8 @@ public class XMLSecurityProperties {
     private QName signaturePositionQName;
     private boolean signaturePositionStart = false;
     private AlgorithmParameterSpec algorithmParameterSpec;
+    private int base64LineLength = XMLUtils.DEFAULT_BASE64_LINE_LENGTH;
+    private byte[] base64LineSeparator = XMLUtils.DEFAULT_BASE64_LINE_SEPARATOR;
 
     public XMLSecurityProperties() {
     }
@@ -120,6 +123,8 @@ public class XMLSecurityProperties {
         this.signaturePositionQName = xmlSecurityProperties.signaturePositionQName;
         this.signaturePositionStart = xmlSecurityProperties.signaturePositionStart;
         this.algorithmParameterSpec = xmlSecurityProperties.algorithmParameterSpec;
+        this.base64LineSeparator = xmlSecurityProperties.base64LineSeparator;
+        this.base64LineLength = xmlSecurityProperties.base64LineLength;
     }
 
     public boolean isSignaturePositionStart() {
@@ -538,5 +543,45 @@ public class XMLSecurityProperties {
 
     public void setAlgorithmParameterSpec(AlgorithmParameterSpec algorithmParameterSpec) {
         this.algorithmParameterSpec = algorithmParameterSpec;
+    }
+
+    /**
+     * @return the Base64 line separator, or {@code null} for no line separator.
+     */
+    public byte[] getBase64LineSeparator() {
+        return base64LineSeparator;
+    }
+
+    /**
+     * Sets the Base64 line separator to the given US-ASCII bytes.
+     * The default is CRLF.
+     * For no line separator, use the combination of {@code base64LineLength = 4} and
+     * {@code base64LineSeparator = null}.
+     *
+     * @param base64LineSeparator a Base64 line separator, or {@code null} for no line separator.
+     * @see #setBase64LineLength(int)
+     */
+    public void setBase64LineSeparator(byte[] base64LineSeparator) {
+        this.base64LineSeparator = base64LineSeparator;
+    }
+
+    /**
+     * @return the Base64 line length, possibly &le; {@code 0} for no line separator.
+     */
+    public int getBase64LineLength() {
+        return base64LineLength;
+    }
+
+    /**
+     * Sets the Base64 line length, which must be a multiple of 4.
+     * The default is 76.
+     * For no line separator, use the combination of {@code base64LineLength = 4} and
+     * {@code base64LineSeparator = null}.
+     *
+     * @param base64LineLength a Base64 line length, or {@code 0} for no line separator.
+     * @see #setBase64LineSeparator(byte[])
+     */
+    public void setBase64LineLength(int base64LineLength) {
+        this.base64LineLength = base64LineLength;
     }
 }

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractEncryptOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractEncryptOutputProcessor.java
@@ -174,12 +174,7 @@ public abstract class AbstractEncryptOutputProcessor extends AbstractOutputProce
                 symmetricCipher.init(Cipher.ENCRYPT_MODE, encryptionPartDef.getSymmetricKey(), parameterSpec);
 
                 characterEventGeneratorOutputStream = new CharacterEventGeneratorOutputStream();
-                Base64OutputStream base64EncoderStream = null;
-                if (XMLUtils.isIgnoreLineBreaks()) {
-                    base64EncoderStream = new Base64OutputStream(characterEventGeneratorOutputStream, true, 0, null);
-                } else {
-                    base64EncoderStream = new Base64OutputStream(characterEventGeneratorOutputStream, true);
-                }
+                Base64OutputStream base64EncoderStream = XMLUtils.createBase64OutputStream(characterEventGeneratorOutputStream, true);
                 base64EncoderStream.write(iv);
 
                 OutputStream outputStream = new CipherOutputStream(base64EncoderStream, symmetricCipher);

--- a/src/main/java/org/apache/xml/security/utils/ElementProxy.java
+++ b/src/main/java/org/apache/xml/security/utils/ElementProxy.java
@@ -292,9 +292,6 @@ public abstract class ElementProxy {
             el.appendChild(text);
 
             appendSelf(el);
-            if (!XMLUtils.ignoreLineBreaks()) {
-                appendSelf(createText("\n"));
-            }
         }
     }
 
@@ -320,9 +317,7 @@ public abstract class ElementProxy {
      */
     public void addBase64Text(byte[] bytes) {
         if (bytes != null) {
-            Text t = XMLUtils.ignoreLineBreaks()
-                ? createText(XMLUtils.encodeToString(bytes))
-                : createText("\n" + XMLUtils.encodeToString(bytes) + "\n");
+            Text t = createText(XMLUtils.encodeToString(bytes));
             appendSelf(t);
         }
     }


### PR DESCRIPTION
* Made Base64 line length and separator configurable on `XMLSecurityProperties`.
* Used a thread-local on `XMLUtils` to hold the Base64 parameters per thread. The alternative is to pass them as parameters to `XMLUtils.encode`, which is what I started doing at first, but it lead to a lot more code changes since the parameters have to be passed everywhere through the whole call stack. The approach with the thread-local seemed like a good alternative, certainly no worse than the configuration with the system property.
* Removed some ad-hoc usages of the static calls to `XMLUtils.ignoreLineBreaks` and `isIgnoreLineBreaks`.
* Deprecated both static methods `ignoreLineBreaks` and `isIgnoreLineBreaks`, because the new mechanism for configuring Base64 parameters is far more flexible. I considered removing those methods, but I decided not to because they're part of the public API of Santuario and it's probably not a good idea to remove them just yet.
* Kept the default CRLF and system property for backward compatibility. I considered removing the system property, but decided not to because I didn't want to affect existing behavior too much. It would be best to remove it at some point though.
* Added unit tests, including a test for concurrent usage.