### PR TITLE
SANTUARIO-533 Renamed ENCRYPT to ENCRYPTION to align with SIGNATURE

### DIFF
--- a/src/main/java/org/apache/xml/security/stax/ext/OutboundXMLSec.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/OutboundXMLSec.java
@@ -133,7 +133,7 @@ public class OutboundXMLSec {
                         signEntireRequestPart = securePart;
                     }
                 }
-            } else if (XMLSecurityConstants.ENCRYPT.equals(action)) {
+            } else if (XMLSecurityConstants.ENCRYPTION.equals(action)) {
                 XMLEncryptOutputProcessor encryptOutputProcessor = new XMLEncryptOutputProcessor();
                 initializeOutputProcessor(outputProcessorChain, encryptOutputProcessor, action);
 

--- a/src/main/java/org/apache/xml/security/stax/ext/XMLSec.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/XMLSec.java
@@ -165,7 +165,7 @@ public class XMLSec {
                 if (securityProperties.getSignatureKeyIdentifiers().isEmpty()) {
                     securityProperties.setSignatureKeyIdentifier(SecurityTokenConstants.KeyIdentifier_IssuerSerial);
                 }
-            } else if (XMLSecurityConstants.ENCRYPT.equals(action)) {
+            } else if (XMLSecurityConstants.ENCRYPTION.equals(action)) {
                 if (securityProperties.getEncryptionKeyTransportAlgorithm() == null) {
                     //@see http://www.w3.org/TR/2002/REC-xmlenc-core-20021210/Overview.html#rsa-1_5 :
                     //"RSA-OAEP is RECOMMENDED for the transport of AES keys"

--- a/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityConstants.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/XMLSecurityConstants.java
@@ -261,7 +261,12 @@ public class XMLSecurityConstants {
     public static final String ENCRYPTION_PARTS = "encryptionParts";
 
     public static final Action SIGNATURE = new Action("Signature");
-    public static final Action ENCRYPT = new Action("Encrypt");
+    public static final Action ENCRYPTION = new Action("Encryption");
+    /**
+     * Use {@link #ENCRYPTION} instead.
+     */
+    @Deprecated
+    public static final Action ENCRYPT = ENCRYPTION;
 
     public static final QName TAG_dsigmore_RSAPSSPARAMS = new QName(NS_DSIG_MORE_2007_05, "RSAPSSParams", PREFIX_DSIG_MORE_PSS);
     public static final QName TAG_dsigmore_SALTLENGTH = new QName(NS_DSIG_MORE_2007_05, "SaltLength", PREFIX_DSIG_MORE_PSS);

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/input/XMLSecurityInputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/input/XMLSecurityInputProcessor.java
@@ -54,7 +54,7 @@ public class XMLSecurityInputProcessor extends AbstractInputProcessor {
         // If no actions are set (default behaviour) we do signature and decryption processing
         // If the only action is XMLSecurityConstants.ENCRYPT then we only do decryption and skip signature processing
         decryptOnly = securityProperties.getActions().size() == 1 &&
-                securityProperties.getActions().contains(XMLSecurityConstants.ENCRYPT);
+                securityProperties.getActions().contains(XMLSecurityConstants.ENCRYPTION);
     }
 
     @Override

--- a/src/test/java/org/apache/xml/security/test/stax/encryption/DecryptionTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/encryption/DecryptionTest.java
@@ -1845,7 +1845,7 @@ public class DecryptionTest {
         // Decrypt
         XMLSecurityProperties properties = new XMLSecurityProperties();
         properties.setDecryptionKey(secretKey);
-        properties.addAction(XMLSecurityConstants.ENCRYPT);
+        properties.addAction(XMLSecurityConstants.ENCRYPTION);
         InboundXMLSec inboundXMLSec = XMLSec.getInboundWSSec(properties);
         TestSecurityEventListener securityEventListener = new TestSecurityEventListener();
         XMLStreamReader securityStreamReader =
@@ -1906,7 +1906,7 @@ public class DecryptionTest {
         // Decrypt
         XMLSecurityProperties properties = new XMLSecurityProperties();
         properties.setDecryptionKey(secretKey);
-        properties.addAction(XMLSecurityConstants.ENCRYPT);
+        properties.addAction(XMLSecurityConstants.ENCRYPTION);
         InboundXMLSec inboundXMLSec = XMLSec.getInboundWSSec(properties);
         TestSecurityEventListener securityEventListener = new TestSecurityEventListener();
         XMLStreamReader securityStreamReader =
@@ -1964,7 +1964,7 @@ public class DecryptionTest {
         // Decrypt
         XMLSecurityProperties properties = new XMLSecurityProperties();
         properties.setDecryptionKey(secretKey);
-        properties.addAction(XMLSecurityConstants.ENCRYPT);
+        properties.addAction(XMLSecurityConstants.ENCRYPTION);
         InboundXMLSec inboundXMLSec = XMLSec.getInboundWSSec(properties);
         TestSecurityEventListener securityEventListener = new TestSecurityEventListener();
         XMLStreamReader securityStreamReader =

--- a/src/test/java/org/apache/xml/security/test/stax/encryption/EncryptionCreationTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/encryption/EncryptionCreationTest.java
@@ -91,7 +91,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -149,7 +149,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -205,7 +205,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -238,10 +238,19 @@ public class EncryptionCreationTest {
 
     @Test
     public void testEncryptionElementCreation() throws Exception {
+        testEncryptElementCreation(XMLSecurityConstants.ENCRYPTION);
+    }
+
+    @Test
+    public void testEncryptBackwardCompatibility() throws Exception {
+        testEncryptElementCreation(XMLSecurityConstants.ENCRYPT);
+    }
+
+    private void testEncryptElementCreation(XMLSecurityConstants.Action action) throws Exception {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(action);
         properties.setActions(actions);
 
         // Set the key up
@@ -299,7 +308,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -358,7 +367,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -412,7 +421,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -478,7 +487,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -546,7 +555,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -615,7 +624,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -685,7 +694,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -749,7 +758,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -820,7 +829,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -899,7 +908,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -970,7 +979,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1041,7 +1050,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1115,7 +1124,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1179,7 +1188,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1240,7 +1249,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1303,7 +1312,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1368,7 +1377,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1435,7 +1444,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1497,7 +1506,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1560,7 +1569,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -1622,7 +1631,7 @@ public class EncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up - only specify a transport key, so the session key gets generated

--- a/src/test/java/org/apache/xml/security/test/stax/encryption/KeyWrapEncryptionCreationTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/encryption/KeyWrapEncryptionCreationTest.java
@@ -109,7 +109,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -177,7 +177,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -245,7 +245,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -313,7 +313,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -379,7 +379,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -444,7 +444,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -509,7 +509,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -576,7 +576,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -646,7 +646,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -716,7 +716,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key
@@ -786,7 +786,7 @@ public class KeyWrapEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set up the Key

--- a/src/test/java/org/apache/xml/security/test/stax/encryption/SymmetricEncryptionCreationTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/encryption/SymmetricEncryptionCreationTest.java
@@ -101,7 +101,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -162,7 +162,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -223,7 +223,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -284,7 +284,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -345,7 +345,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -406,7 +406,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -467,7 +467,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -529,7 +529,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -591,7 +591,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -653,7 +653,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -715,7 +715,7 @@ public class SymmetricEncryptionCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up

--- a/src/test/java/org/apache/xml/security/test/stax/encryption/XMLEncryption11Test.java
+++ b/src/test/java/org/apache/xml/security/test/stax/encryption/XMLEncryption11Test.java
@@ -541,7 +541,7 @@ public class XMLEncryption11Test {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         properties.setEncryptionTransportKey(encryptedKey);

--- a/src/test/java/org/apache/xml/security/test/stax/performance/AbstractPerformanceTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/performance/AbstractPerformanceTest.java
@@ -181,7 +181,7 @@ public abstract class AbstractPerformanceTest {
     protected void setUpOutboundEncryptionXMLSec() throws XMLSecurityException {
         XMLSecurityProperties xmlSecurityProperties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         xmlSecurityProperties.setActions(actions);
         xmlSecurityProperties.setEncryptionKey(encryptionSymKey);
         xmlSecurityProperties.setEncryptionSymAlgorithm("http://www.w3.org/2001/04/xmlenc#aes256-cbc");

--- a/src/test/java/org/apache/xml/security/test/stax/signature/SignatureEncryptionTest.java
+++ b/src/test/java/org/apache/xml/security/test/stax/signature/SignatureEncryptionTest.java
@@ -69,7 +69,7 @@ public class SignatureEncryptionTest extends AbstractSignatureCreationTest {
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
         actions.add(XMLSecurityConstants.SIGNATURE);
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -138,7 +138,7 @@ public class SignatureEncryptionTest extends AbstractSignatureCreationTest {
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
         actions.add(XMLSecurityConstants.SIGNATURE);
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -207,7 +207,7 @@ public class SignatureEncryptionTest extends AbstractSignatureCreationTest {
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
         actions.add(XMLSecurityConstants.SIGNATURE);
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -284,7 +284,7 @@ public class SignatureEncryptionTest extends AbstractSignatureCreationTest {
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
         actions.add(XMLSecurityConstants.SIGNATURE);
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         properties.setActions(actions);
 
         // Set the key up
@@ -360,7 +360,7 @@ public class SignatureEncryptionTest extends AbstractSignatureCreationTest {
         // Set up the Configuration
         XMLSecurityProperties properties = new XMLSecurityProperties();
         List<XMLSecurityConstants.Action> actions = new ArrayList<>();
-        actions.add(XMLSecurityConstants.ENCRYPT);
+        actions.add(XMLSecurityConstants.ENCRYPTION);
         actions.add(XMLSecurityConstants.SIGNATURE);
         properties.setActions(actions);
 


### PR DESCRIPTION
* Renamed `ENCRYPT` to `ENCRYPTION` to align with `SIGNATURE`.
* Deprecated `ENCRYPT` and redirected it to `ENCRYPTION`.