### PR TITLE
SANTUARIO-535 Replaced useless abstract method processEvent

### DIFF
--- a/src/main/java/org/apache/xml/security/stax/ext/AbstractBufferingOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/AbstractBufferingOutputProcessor.java
@@ -41,7 +41,7 @@ public abstract class AbstractBufferingOutputProcessor extends AbstractOutputPro
     }
 
     @Override
-    public void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
+    public void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
             throws XMLStreamException, XMLSecurityException {
         xmlSecEventBuffer.offer(xmlSecEvent);
     }

--- a/src/main/java/org/apache/xml/security/stax/ext/AbstractOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/ext/AbstractOutputProcessor.java
@@ -124,15 +124,6 @@ public abstract class AbstractOutputProcessor implements OutputProcessor {
         return action;
     }
 
-    public abstract void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
-            throws XMLStreamException, XMLSecurityException;
-
-    @Override
-    public void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
-            throws XMLStreamException, XMLSecurityException {
-        processEvent(xmlSecEvent, outputProcessorChain);
-    }
-
     @Override
     public void doFinal(OutputProcessorChain outputProcessorChain) throws XMLStreamException, XMLSecurityException {
         outputProcessorChain.doFinal();

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractEncryptOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractEncryptOutputProcessor.java
@@ -80,7 +80,7 @@ public abstract class AbstractEncryptOutputProcessor extends AbstractOutputProce
     }
 
     @Override
-    public abstract void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
+    public abstract void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
             throws XMLStreamException, XMLSecurityException;
 
     @Override
@@ -215,7 +215,7 @@ public abstract class AbstractEncryptOutputProcessor extends AbstractOutputProce
         }
 
         @Override
-        public void processEvent(final XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
+        public void processNextEvent(final XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
                 throws XMLStreamException, XMLSecurityException {
 
             switch (xmlSecEvent.getEventType()) {

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractSignatureEndingOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractSignatureEndingOutputProcessor.java
@@ -357,7 +357,7 @@ public abstract class AbstractSignatureEndingOutputProcessor extends AbstractBuf
         }
 
         @Override
-        public void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
+        public void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
                 throws XMLStreamException, XMLSecurityException {
             transformer.transform(xmlSecEvent);
             outputProcessorChain.processEvent(xmlSecEvent);

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractSignatureOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/AbstractSignatureOutputProcessor.java
@@ -74,7 +74,7 @@ public abstract class AbstractSignatureOutputProcessor extends AbstractOutputPro
     }
 
     @Override
-    public abstract void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
+    public abstract void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
             throws XMLStreamException, XMLSecurityException;
 
     @Override
@@ -282,7 +282,7 @@ public abstract class AbstractSignatureOutputProcessor extends AbstractOutputPro
         }
 
         @Override
-        public void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
+        public void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain)
                 throws XMLStreamException, XMLSecurityException {
 
             transformer.transform(xmlSecEvent);

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/FinalOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/FinalOutputProcessor.java
@@ -56,7 +56,7 @@ public class FinalOutputProcessor extends AbstractOutputProcessor {
     }
 
     @Override
-    public void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain) throws XMLStreamException, XMLSecurityException {
+    public void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain) throws XMLStreamException, XMLSecurityException {
         xmlEventWriter.add(xmlSecEvent);
     }
 

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLEncryptOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLEncryptOutputProcessor.java
@@ -68,7 +68,7 @@ public class XMLEncryptOutputProcessor extends AbstractEncryptOutputProcessor {
     }
 
     @Override
-    public void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain) throws XMLStreamException, XMLSecurityException {
+    public void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain) throws XMLStreamException, XMLSecurityException {
         if (xmlSecEvent.getEventType() == XMLStreamConstants.START_ELEMENT) {
             XMLSecStartElement xmlSecStartElement = xmlSecEvent.asStartElement();
 

--- a/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLSignatureOutputProcessor.java
+++ b/src/main/java/org/apache/xml/security/stax/impl/processor/output/XMLSignatureOutputProcessor.java
@@ -58,7 +58,7 @@ public class XMLSignatureOutputProcessor extends AbstractSignatureOutputProcesso
     }
 
     @Override
-    public void processEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain) throws XMLStreamException, XMLSecurityException {
+    public void processNextEvent(XMLSecEvent xmlSecEvent, OutputProcessorChain outputProcessorChain) throws XMLStreamException, XMLSecurityException {
         if (xmlSecEvent.getEventType() == XMLStreamConstants.START_ELEMENT) {
             XMLSecStartElement xmlSecStartElement = xmlSecEvent.asStartElement();
 


### PR DESCRIPTION
Replaced useless abstract method `processEvent` with `processNextEvent` from interface.